### PR TITLE
Feat/custom configs squid conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Custom whitelist groups made of a name, **N** hosts and **N** domains.
           - .google.com
           - .google.com.br
     ```
+`squid_custom_configs`     
+Custom configs of any kind.
 
 Dependencies
 ------------
@@ -126,10 +128,29 @@ Example Playbook
   ```
   or you can add the variable `squid_custom_whitelist` in the `host_vars/group_vars`, remember to follow the same format.
 
+* If you want to pass a config that isn't covered from the other variables, pass `squid_custom_configs`:
+  ```yml
+  ---
+  - name: Playbook creating N to N whitelist
+    hosts: all
+    become: true
+    tasks:
+      - name: include custom whitelist
+        include_vars:
+          file: ../files/custom_whitelist.yml
+      - name: execute role
+        include_role:
+          name: stone-payments.squid
+        vars:
+          squid_custom_configs:
+            - "cache_mem 128 MB"
+
+  ```
+
 This role was tested with :
 * `Molecule` 2.2.1
 * `Docker` 18.03.0-ce
-* `Ansible` 2.5.0S
+* `Ansible` 2.5.0
 * `Vagrant` 2.0.2
 * `Virtualbox` 5.1.34
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@
 # squid_custom_acls
 # squid_custom_http_access
 # squid_custom_refresh_pattern
+# squid_custom_whitelist
+# squid_custom_configs
 
 # local subnets
 squid_localnets:

--- a/molecule/resources/playbooks/playbook.yml
+++ b/molecule/resources/playbooks/playbook.yml
@@ -9,3 +9,7 @@
     - name: execute role
       include_role:
         name: stone-payments.squid
+      vars:
+        squid_custom_configs:
+          - "cache_mem 128 MB"
+        squid_diskcache: "aufs {{ squid_coredumpdir }} 1000 16 256"

--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -56,7 +56,13 @@ cache_dir {{ squid_diskcache }}
 
 {% if squid_coredumpdir %}
 coredump_dir {{ squid_coredumpdir }}
-{% endif %} 
+{% endif %}
+
+{% if squid_custom_configs is defined %}
+{% for config in squid_custom_configs %}
+{{ config }}
+{% endfor %}
+{% endif %}
 
 {% for rp in squid_refresh_pattern %}
 refresh_pattern {{ rp.case_sensitive }} {{ rp.regex }} {{ rp.min }} {{ rp.percent }} {{ rp.max }} {{ rp.opts }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This feature includes the possibility to add any config in squid.conf not covered by the variables already created in the role.

## Motivation and Context
The role allows to add some configs such as: 
* `acl`; 
* `http_access`;
* `http_port`;
* `coredump_dir`;
* etc.
But there are many other that the role doesn't cover. For example:
* `cache_mem`;
* or a second `cache_dir`.

## How Has This Been Tested?
It was tested with: 
* `Molecule` 2.12.1
*  `Docker` 18.03.0-ce
*  `Vagrant` 2.0.2
* `VirtualBox` 5.1.34

There are 2 scenarios in `Molecule` using Centos7.4:
* with Docker
* with Vagrant

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)