### PR TITLE
Merge Dev into Master -  Be able to add any config to squid.conf 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Custom whitelist groups made of a name, **N** hosts and **N** domains.
           - .google.com
           - .google.com.br
     ```
+`squid_custom_configs`     
+Custom configs of any kind.
 
 Dependencies
 ------------
@@ -126,10 +128,29 @@ Example Playbook
   ```
   or you can add the variable `squid_custom_whitelist` in the `host_vars/group_vars`, remember to follow the same format.
 
+* If you want to pass a config that isn't covered from the other variables, pass `squid_custom_configs`:
+  ```yml
+  ---
+  - name: Playbook creating N to N whitelist
+    hosts: all
+    become: true
+    tasks:
+      - name: include custom whitelist
+        include_vars:
+          file: ../files/custom_whitelist.yml
+      - name: execute role
+        include_role:
+          name: stone-payments.squid
+        vars:
+          squid_custom_configs:
+            - "cache_mem 128 MB"
+
+  ```
+
 This role was tested with :
 * `Molecule` 2.2.1
 * `Docker` 18.03.0-ce
-* `Ansible` 2.5.0S
+* `Ansible` 2.5.0
 * `Vagrant` 2.0.2
 * `Virtualbox` 5.1.34
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@
 # squid_custom_acls
 # squid_custom_http_access
 # squid_custom_refresh_pattern
+# squid_custom_whitelist
+# squid_custom_configs
 
 # local subnets
 squid_localnets:

--- a/molecule/resources/playbooks/playbook.yml
+++ b/molecule/resources/playbooks/playbook.yml
@@ -12,4 +12,4 @@
       vars:
         squid_custom_configs:
           - "cache_mem 128 MB"
-        squid_diskcache: "aufs {{ squid_coredumpdir }} 1000 16 256"
+        squid_diskcache: "aufs {{ squid_cache_dir }} 1000 16 256"

--- a/molecule/resources/playbooks/playbook.yml
+++ b/molecule/resources/playbooks/playbook.yml
@@ -9,3 +9,7 @@
     - name: execute role
       include_role:
         name: stone-payments.squid
+      vars:
+        squid_custom_configs:
+          - "cache_mem 128 MB"
+        squid_diskcache: "aufs {{ squid_coredumpdir }} 1000 16 256"

--- a/tasks/custom-whitelist.yml
+++ b/tasks/custom-whitelist.yml
@@ -9,9 +9,16 @@
     squid_custom_acls: "{{ squid_custom_acls|default([]) +[{'name': item.name+'_dstdomain', 'type': 'dstdomain', 'arg': '\"/etc/squid/'+item.name+'_dstdomain\"'}] }}"
   with_items: "{{ squid_custom_whitelist }}"
 
+- name: populate squid_custom_http_access with dest empty
+  set_fact:
+    squid_custom_http_access: "{{ squid_custom_http_access|default([]) +[{'aclname': item.name+'_src', 'perm': 'allow'}] }}"
+  when: item.dest is not defined or item.dest|length == 0 or item.dest.0 == None
+  with_items: "{{ squid_custom_whitelist }}"
+
 - name: populate squid_custom_http_access
   set_fact:
     squid_custom_http_access: "{{ squid_custom_http_access|default([]) +[{'aclname': item.name+'_dstdomain '+item.name+'_src', 'perm': 'allow'}] }}"
+  when: item.dest is defined and item.dest|length > 0 and item.dest.0 != None
   with_items: "{{ squid_custom_whitelist }}"
 
 - name: make sure /etc/squid dir exists
@@ -30,5 +37,6 @@
   template:
     src: dest_file.j2
     dest: "/etc/squid/{{ item.name }}_dstdomain"
+  when: item.dest is defined and item.dest|length > 0 and item.dest.0 != None
   with_items: "{{ squid_custom_whitelist }}"
   notify: restart squid

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Create custom whitelist groups
   include: custom-whitelist.yml
-  when: squid_custom_whitelist is defined
+  when: squid_custom_whitelist is defined and squid_custom_whitelist
 
 # Install RedHat-like
 - include: squid-RedHat.yml

--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -56,7 +56,13 @@ cache_dir {{ squid_diskcache }}
 
 {% if squid_coredumpdir %}
 coredump_dir {{ squid_coredumpdir }}
-{% endif %} 
+{% endif %}
+
+{% if squid_custom_configs is defined %}
+{% for config in squid_custom_configs %}
+{{ config }}
+{% endfor %}
+{% endif %}
 
 {% for rp in squid_refresh_pattern %}
 refresh_pattern {{ rp.case_sensitive }} {{ rp.regex }} {{ rp.min }} {{ rp.percent }} {{ rp.max }} {{ rp.opts }}

--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -54,15 +54,13 @@ http_port {{ squid_port }}
 cache_dir {{ squid_diskcache }}
 {% endif %}
 
-{% if squid_coredumpdir %}
-coredump_dir {{ squid_coredumpdir }}
-{% endif %}
-
 {% if squid_custom_configs is defined %}
 {% for config in squid_custom_configs %}
 {{ config }}
 {% endfor %}
 {% endif %}
+
+coredump_dir /dev/null
 
 {% for rp in squid_refresh_pattern %}
 refresh_pattern {{ rp.case_sensitive }} {{ rp.regex }} {{ rp.min }} {{ rp.percent }} {{ rp.max }} {{ rp.opts }}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,8 +3,7 @@ squid_package: squid
 squid_daemon: squid
 squid_path: /etc/squid
 squid_conf: /etc/squid/squid.conf
+squid_cache_dir: /var/spool/squid
 
-squid_diskcache: 'ufs /var/spool/squid 100 16 256'
+squid_diskcache: 'ufs {{ squid_cache_dir }} 100 16 256'
 #squid_diskcache: '' # Disables cache
-
-squid_coredumpdir: '/var/spool/squid'

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,8 +3,7 @@ squid_package: squid
 squid_daemon: squid
 squid_path: /etc/squid
 squid_conf: /etc/squid/squid.conf
+squid_cache_dir: /var/spool/squid
 
-squid_diskcache: 'ufs /var/spool/squid 100 16 256'
+squid_diskcache: 'ufs {{ squid_cache_dir }} 100 16 256'
 #squid_diskcache: '' # Disables cache
-
-squid_coredumpdir: '/var/spool/squid'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This feature includes the possibility to add any config in squid.conf not covered by the variables already created in the role.

## Motivation and Context
The role allows to add some configs such as: 
* `acl`; 
* `http_access`;
* `http_port`;
* `coredump_dir`;
* etc.
But there are many other that the role doesn't cover. For example:
* `cache_mem`;
* or a second `cache_dir`.

## How Has This Been Tested?
It was tested with: 
* `Molecule` 2.12.1
*  `Docker` 18.03.0-ce
*  `Vagrant` 2.0.2
* `VirtualBox` 5.1.34

There are 2 scenarios in `Molecule` using Centos7.4:
* with Docker
* with Vagrant

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)