### PR TITLE
Be able to create http_access without dstdomain

### DIFF
--- a/tasks/custom-whitelist.yml
+++ b/tasks/custom-whitelist.yml
@@ -9,9 +9,16 @@
     squid_custom_acls: "{{ squid_custom_acls|default([]) +[{'name': item.name+'_dstdomain', 'type': 'dstdomain', 'arg': '\"/etc/squid/'+item.name+'_dstdomain\"'}] }}"
   with_items: "{{ squid_custom_whitelist }}"
 
+- name: populate squid_custom_http_access with dest empty
+  set_fact:
+    squid_custom_http_access: "{{ squid_custom_http_access|default([]) +[{'aclname': item.name+'_src', 'perm': 'allow'}] }}"
+  when: item.dest is not defined or item.dest|length == 0 or item.dest.0 == None
+  with_items: "{{ squid_custom_whitelist }}"
+
 - name: populate squid_custom_http_access
   set_fact:
     squid_custom_http_access: "{{ squid_custom_http_access|default([]) +[{'aclname': item.name+'_dstdomain '+item.name+'_src', 'perm': 'allow'}] }}"
+  when: item.dest is defined and item.dest|length > 0 and item.dest.0 != None
   with_items: "{{ squid_custom_whitelist }}"
 
 - name: make sure /etc/squid dir exists
@@ -30,5 +37,6 @@
   template:
     src: dest_file.j2
     dest: "/etc/squid/{{ item.name }}_dstdomain"
+  when: item.dest is defined and item.dest|length > 0 and item.dest.0 != None
   with_items: "{{ squid_custom_whitelist }}"
   notify: restart squid


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This feature includes the possibility to add whitelist groups without a dest, allowing full access to sources.

## Motivation and Context
There wasn't a way to create a whitelist group giving full access to sources using the new way to create n-to-n whitelist.

## How Has This Been Tested?
It was tested with: 
* `Molecule` 2.12.1
*  `Docker` 18.03.0-ce
*  `Vagrant` 2.0.2
* `VirtualBox` 5.1.34

There are 2 scenarios in `Molecule` using Centos7.4:
* with Docker
* with Vagrant

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)