### PR TITLE
Remove duplicated code from RedHat and Debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,10 +6,9 @@
   include: custom-whitelist.yml
   when: squid_custom_whitelist is defined and squid_custom_whitelist
 
-# Install RedHat-like
-- include: squid-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+- name: install squid
+  package: name={{ squid_package }} state=present update_cache=yes
 
-# Install Debian-like
-- include: squid-Debian.yml
-  when: ansible_os_family == 'Debian'
+- name: copy template
+  template: src=squid.conf.j2 dest={{ squid_conf }} owner=root group=root mode=0644
+  notify: restart squid

--- a/tasks/squid-Debian.yml
+++ b/tasks/squid-Debian.yml
@@ -1,7 +1,0 @@
----
-- name: install squid3
-  apt: name={{ squid_package }} state=present update_cache=yes
-
-- name: copy template
-  template: src=squid.conf.j2 dest={{ squid_conf }} owner=root group=root mode=0644
-  notify: restart squid

--- a/tasks/squid-RedHat.yml
+++ b/tasks/squid-RedHat.yml
@@ -1,7 +1,0 @@
----
-- name: install squid
-  package: name={{ squid_package }} state=present update_cache=yes
-
-- name: copy template
-  template: src=squid.conf.j2 dest={{ squid_conf }} owner=root group=root mode=0644
-  notify: restart squid

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,6 +4,3 @@ squid_daemon: squid
 squid_path: /etc/squid
 squid_conf: /etc/squid/squid.conf
 squid_cache_dir: /var/spool/squid
-
-squid_diskcache: 'ufs {{ squid_cache_dir }} 100 16 256'
-#squid_diskcache: '' # Disables cache

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,6 +4,3 @@ squid_daemon: squid
 squid_path: /etc/squid
 squid_conf: /etc/squid/squid.conf
 squid_cache_dir: /var/spool/squid
-
-squid_diskcache: 'ufs {{ squid_cache_dir }} 100 16 256'
-#squid_diskcache: '' # Disables cache

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for squid
+squid_diskcache: 'ufs {{ squid_cache_dir }} 100 16 256'


### PR DESCRIPTION
This PR removes duplicated code that was supposed to treat differently RedHat and Debian distros. However, upon a closer inspection, it was determined that such differentiation was unwarranted and could be removed.
